### PR TITLE
Minor improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
     }],
     'no-underscore-dangle': ['error', { allowAfterThis: true }],
     'no-console': 'off',
-    
   },
   
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  // collectCoverage: true,
+  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint --fix --color --format table src/js test",
     "test": "jest",
     "test-coverage": "jest --coverage --silent",
-    "prebuild": "npm run test",
+    "prebuild": "npm run lint && npm run test",
     "build": "webpack",
     "document": "jsdoc --configure jsdoc.conf.json",
     "postbuild": "npm run document",


### PR DESCRIPTION
- removed empty line from .eslintrc.js
- enabled Jest collectCoverage. Showing code coverage overview during build or testing
- added ESLint to the NPM prebuild. As it was impossible to configure webpack, to include the test folder for linting